### PR TITLE
Send reply to dev-escalation main thread with the Github task body

### DIFF
--- a/sources/factories/SlackMessageFactory.py
+++ b/sources/factories/SlackMessageFactory.py
@@ -33,9 +33,15 @@ class SlackMessageFactory(SlackFactoryAbstract):
         request_open_view_payload = {}
         request_open_view_payload['channel'] = channel
         request_open_view_payload['text'] = text
-        requests.post(url=self.post_message_url,
-                      headers=request_open_view_header,
-                      json=request_open_view_payload, timeout=3000)
+        result = requests.post(url=self.post_message_url,
+                               headers=request_open_view_header,
+                               json=request_open_view_payload, timeout=3000)
+        if result is None:
+            raise ValueError('Slack post message failed.')
+        result_json = result.json()
+        if result_json["ok"] is False:
+            raise ValueError('Slack post message was not completed.')
+        return result_json
 
     def post_reply(self, app_context, channel, thread_ts, text):
         """

--- a/sources/handlers/GithubTaskHandler.py
+++ b/sources/handlers/GithubTaskHandler.py
@@ -93,13 +93,19 @@ class GithubTaskHandler():
                 self.github_gql_call_factory.set_task_to_dev_team_escalation_type(app_context, project_item.item_id)
 
                 # Send message on Slack channel
-                text = f"{task_params.title} by <@{task_params.initiator}>: " + self.get_task_link(
+                main_text = f"{task_params.title} by <@{task_params.initiator}>: " + self.get_task_link(
                     project_item.project_number,
                     self.get_board_view(task_params.flow),
                     project_item.item_database_id)
-                self.slack_message_factory.post_message(app_context,
-                                                        self.slack_message_factory.get_channel(task_params.flow),
-                                                        text)
+                thread = self.slack_message_factory.post_message(app_context,
+                                                                 self.slack_message_factory.get_channel(task_params.flow),
+                                                                 main_text)
+
+                # Add details of the escalation in the thread
+                if thread is not None:
+                    detail_text = f"{task_params.body}"
+                    self.slack_message_factory.post_reply(app_context,
+                                                          thread["channel"], thread["ts"], detail_text)
 
     def process_update(self, app_context, node_id):
         """

--- a/tests/unit/GithubTaskHandlerTest.py
+++ b/tests/unit/GithubTaskHandlerTest.py
@@ -205,10 +205,30 @@ def test_init_github_task_no_initiator(mock_post_message, mock_getuser, mock_set
 @patch.object(GithubGQLCallFactory, "set_task_to_current_sprint")
 @patch.object(GithubGQLCallFactory, "get_user_id_from_login", return_value='the_user_id')
 @patch.object(GithubGQLCallFactory, "set_task_to_dev_team_escalation_type")
-@patch.object(SlackMessageFactory, "post_message")
+@patch.object(SlackMessageFactory, "post_message", return_value={
+                                                                "ok": True,
+                                                                "channel": "C123ABC456",
+                                                                "ts": "1503435956.000247",
+                                                                "message": {
+                                                                    "text": "Here's a message for you",
+                                                                    "username": "ecto1",
+                                                                    "bot_id": "B123ABC456",
+                                                                    "attachments": [
+                                                                        {
+                                                                            "text": "This is an attachment",
+                                                                            "id": 1,
+                                                                            "fallback": "This is an attachment's fallback"
+                                                                        }
+                                                                    ],
+                                                                    "type": "message",
+                                                                    "subtype": "bot_message",
+                                                                    "ts": "1503435956.000247"
+                                                                }
+                                                            })
+@patch.object(SlackMessageFactory, "post_reply")
 @patch.object(SlackMessageFactory, "get_channel", return_value='the_escalation_channel')
 # pylint: disable-next=too-many-arguments
-def test_init_github_task_dev_team_escalation(mock_getchannel, mock_post_message, mock_settasktype,
+def test_init_github_task_dev_team_escalation(mock_getchannel, mock_post_reply, mock_post_message, mock_settasktype,
                                               mock_getuser, mock_setsprint, mock_setstatus, mock_createtask):
     """
         Test init_github_task with the dev-team-escalation flow ot check the type is set
@@ -221,6 +241,9 @@ def test_init_github_task_dev_team_escalation(mock_getchannel, mock_post_message
 
     call_post_message = [call('app_context', 'U123456789', ANY), call('app_context', 'the_escalation_channel', ANY)]
     mock_post_message.assert_has_calls(call_post_message)
+
+    call_post_reply = [call('app_context', 'C123ABC456', "1503435956.000247", "the_body")]
+    mock_post_reply.assert_has_calls(call_post_reply)
 
     call_set_task_type = [call('app_context', "the_project_item_id")]
     mock_settasktype.assert_has_calls(call_set_task_type)

--- a/tests/unit/SlackMessageFactoryTest.py
+++ b/tests/unit/SlackMessageFactoryTest.py
@@ -13,7 +13,7 @@ def mock_request_post_message_check_params(*args, **kwargs):
     """
         Mocks the requests.post and check basic values for test_post_message
     """
-    class RequestReturn(object):
+    class RequestReturn():
         """
             Mocks the return of requests.post
          """

--- a/tests/unit/SlackMessageFactoryTest.py
+++ b/tests/unit/SlackMessageFactoryTest.py
@@ -13,9 +13,42 @@ def mock_request_post_message_check_params(*args, **kwargs):
     """
         Mocks the requests.post and check basic values for test_post_message
     """
+    class RequestReturn(object):
+        """
+            Mocks the return of requests.post
+         """
+        status_code = 200
+
+        def json(self):
+            """
+                Mocks the json method of requests.post's return
+            """
+            json = {"ok": True,
+                    "channel": "C123ABC456",
+                    "ts": "1503435956.000247",
+                    "message": {
+                        "text": "Here's a message for you",
+                        "username": "ecto1",
+                        "bot_id": "B123ABC456",
+                        "attachments": [
+                            {
+                                "text": "This is an attachment",
+                                "id": 1,
+                                "fallback": "This is an attachment's fallback"
+                            }
+                        ],
+                        "type": "message",
+                        "subtype": "bot_message",
+                        "ts": "1503435956.000247"
+                    }
+                    }
+            return json
+
     assert 'https://slack.com/api/chat.postMessage' == kwargs['url']
     assert {"Content-type": "application/json", "Authorization": "Bearer " + 'the_token'} == kwargs['headers']
     assert {"channel": "the_channel", "text": "the_text"} == kwargs['json']
+    response = RequestReturn()
+    return response
 
 
 def mock_request_post_reply_check_params(*args, **kwargs):


### PR DESCRIPTION
## Description

On the dev-team escalation flow, add a "post_reply" call to Slack, following the "post_message" call so that a threaded comment is added, with the body of the GitHub task.

Fixes #37 

## Type of change

*Please delete options that are not relevant.*

- Enhancement (non-breaking change which improves an existing functionality).
- This change requires a documentation update.

## Is the solution different from the one proposed during the grooming?

No gromming.

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [x] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [x] If applicable, I have made corresponding changes to the documentation. https://www.notion.so/wpmedia/TB-TT-137d921c1ff947c4a19e9d0a83262e6a?pvs=4#7e2389443e2f4cad9f987e32d99fbca5

## Test summary

- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.

Tested locally with a custom Slack App on a dedicated workspace, and WP Media Github