### PR TITLE
Add Metasearch in config for the Release Note automation

### DIFF
--- a/.github/workflows/group.one-deploy-production_v2.yml
+++ b/.github/workflows/group.one-deploy-production_v2.yml
@@ -32,6 +32,7 @@ jobs:
           tag_name: v${{ steps.create_tag.outputs.VERSION }}
           body: ${{ github.event.head_commit.message }}
           target_commitish: master
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
       - name: Deploy to production

--- a/config/github.json
+++ b/config/github.json
@@ -29,7 +29,7 @@
         "rocket-cdn": "RocketCDN",
         "wp-rocket.me": "WP Rocket website",
         "imagify-website": "Imagify website",
-        "rocketcdn-website": "RocketCDN website"
-
+        "rocketcdn-website": "RocketCDN website",
+        "metasearch": "Metasearch"
     }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.3
+info:
+  title: TB-TT
+  description: |-
+   This a description from the endpoints from TB-TT service.
+  contact:
+    email: mathieu@wp-media.me
+  version: 1.0.0
+externalDocs:
+  description: Notion Documentation
+  url: https://www.notion.so/wpmedia/TB-TT-137d921c1ff947c4a19e9d0a83262e6a?pvs=4
+servers:
+  - url: https://wpm-tbtt.public-default.live1-k8s-cph3.one.com
+tags:
+  - name: support
+    description: Automation for the support team
+paths:
+  /support/wprocket-ips:
+    post:
+      description: Retrieves the list of servers and IPs used for WP Media products.
+      tags:
+        - support
+      responses:
+        200:
+          description: The list has been correctly retrieved and returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SupportWPRocketIPsResponse'
+components:
+  schemas:
+    SupportWPRocketIPsResponse:
+      type: string


### PR DESCRIPTION
## Description

Add Metasearch in config for the Release Note automation so that Metasearch releases are advertised on Slack and Notion with release notes.

## Type of change

- Enhancement (non-breaking change which improves an existing functionality).

## Is the solution different from the one proposed during the grooming?

No

# Checklists

## Generic development checklist

- [x] My code follows the style guidelines of this project, with adapted comments and without new warnings.
- [ ] I have added unit and integration tests that prove my fix is effective or that my feature works.
- [x] The CI passes locally with my changes (including unit tests, integration tests, linter).
- [x] Any dependent changes have been merged and published in downstream modules.

## Test summary

- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I validated all Acceptance Criteria of the related issues. (If applicable, provide proof).
- [ ] I validated all test plan the QA Review asked me to.

To be tested in production.