### PR TITLE
Add new live2 IPs according to JIRA NET-283

### DIFF
--- a/sources/handlers/ServerListHandler.py
+++ b/sources/handlers/ServerListHandler.py
@@ -18,6 +18,18 @@ class ServerListHandler():
         self.slack_message_factory = SlackMessageFactory()
         self.ovh_api_factory = OvhApiFactory()
 
+    def get_groupone_live2_ips(self):
+        """
+            Lists all IP used by live2 cluster from group.One
+        """
+        text = ''
+        # Defined in k8s_sips:
+        # https://gitlab.one.com/systems/chef-repo/-/blob/master/roles/onecom-global-firewall-macros.json#L173
+        text += "46.30.212.64\n46.30.212.65\n46.30.212.66\n46.30.212.67\n46.30.212.68\n46.30.212.69\n46.30.211.85\n"
+        # Added for live2 according to JIRA: https://group-one.atlassian.net/browse/NET-283
+        text += "46.30.212.70\n46.30.212.71\n46.30.212.72\n46.30.212.73\n"
+        return text
+
     def generate_wp_rocket_ips(self, app_context):
         """
             Generates a text list of all IPs used by WP Rocket
@@ -34,17 +46,13 @@ class ServerListHandler():
         # Defined in https://gitlab.one.com/systems/group.one-authdns/-/blob/main/octodns/wp-rocket.me.yaml?ref_type=heads
         text += "https://cpcss.wp-rocket.me\n"
         text += "46.30.212.116\n"
-        # Defined in k8s_sips:
-        # https://gitlab.one.com/systems/chef-repo/-/blob/master/roles/onecom-global-firewall-macros.json#L173
-        text += "46.30.212.64\n46.30.212.65\n46.30.212.66\n46.30.212.67\n46.30.212.68\n46.30.212.69\n46.30.211.85\n"
+        text += self.get_groupone_live2_ips()
         text += "\n"
 
         text += "Remove Unused CSS:\n"
         # SaaS CNAME in https://gitlab.one.com/systems/group.one-authdns/-/blob/main/octodns/wp-rocket.me.yaml?ref_type=heads
         text += "46.30.212.106\n"
-        # Defined in k8s_sips:
-        # https://gitlab.one.com/systems/chef-repo/-/blob/master/roles/onecom-global-firewall-macros.json#L173
-        text += "46.30.212.64\n46.30.212.65\n46.30.212.66\n46.30.212.67\n46.30.212.68\n46.30.212.69\n46.30.211.85\n"
+        text += self.get_groupone_live2_ips()
         # OVH servers
         all_server_list = self.ovh_api_factory.get_dedicated_servers(app_context)
         ovh_ipv4 = ''
@@ -68,9 +76,7 @@ class ServerListHandler():
         text += "RocketCDN subscription:\n"
         text += "https://rocketcdn.me/api/\n"
         text += "185.10.9.100\n"
-        # Defined in k8s_sips:
-        # https://gitlab.one.com/systems/chef-repo/-/blob/master/roles/onecom-global-firewall-macros.json#L173
-        text += "46.30.212.64\n46.30.212.65\n46.30.212.66\n46.30.212.67\n46.30.212.68\n46.30.212.69\n46.30.211.85\n"
+        text += self.get_groupone_live2_ips()
 
         return text
 

--- a/sources/handlers/ServerListHandler.py
+++ b/sources/handlers/ServerListHandler.py
@@ -22,13 +22,13 @@ class ServerListHandler():
         """
             Lists all IP used by live2 cluster from group.One
         """
-        text = ''
+        live2_ips = ''
         # Defined in k8s_sips:
         # https://gitlab.one.com/systems/chef-repo/-/blob/master/roles/onecom-global-firewall-macros.json#L173
-        text += "46.30.212.64\n46.30.212.65\n46.30.212.66\n46.30.212.67\n46.30.212.68\n46.30.212.69\n46.30.211.85\n"
-        # Added for live2 according to JIRA: https://group-one.atlassian.net/browse/NET-283
-        text += "46.30.212.70\n46.30.212.71\n46.30.212.72\n46.30.212.73\n"
-        return text
+        live2_ips += "46.30.212.64\n46.30.212.65\n46.30.212.66\n46.30.212.67\n46.30.212.68\n46.30.212.69\n46.30.211.85\n"
+        # Added for live2 according to JIRA: https://group-one.atlassian.net/browse/NET-283
+        live2_ips += "46.30.212.70\n46.30.212.71\n46.30.212.72\n46.30.212.73\n"
+        return live2_ips
 
     def generate_wp_rocket_ips(self, app_context):
         """


### PR DESCRIPTION
# Description

New IPs have been added to group.One live2 and it must be manually reflected in the TB-TT: https://group-one.atlassian.net/browse/NET-283

## Documentation

### User documentation

New IPs will be displayed with the wprocket-ips command, and the API endpoint /support/wprocket-ips

### Technical documentation

Manually added new IPs

## Type of change
*Delete options that are not relevant.*

- [x] Enhancement (non-breaking change which improves an existing functionality).

## New dependencies
None

## Risks
Might be breaking the command and API endpoint if there is an error

# Checklists

## Feature validation

- [ ] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [x] I listed the introduced external dependencies explicitely on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [x] I handled errors when needed.
- [x] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [x] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [x] I explicitely mentioned performance risks in the PR.
- [x] I explicitely mentioned security risks in the PR.
