### PR TITLE
Retry on GQL GitHub failure and stop fetching the gql schema to simpl…

### DIFF
--- a/sources/factories/GithubGQLCallFactory.py
+++ b/sources/factories/GithubGQLCallFactory.py
@@ -44,7 +44,9 @@ class GithubGQLCallFactory():
         """
         github_access_token = self.__get_github_access_token(app_context)
         github_http_transport = RequestsHTTPTransport(
-                url=self.github_gql_url, headers={'Authorization': f'Bearer {github_access_token}'})
+                url=self.github_gql_url, headers={'Authorization': f'Bearer {github_access_token}'},
+                retries=3
+            )
         return github_http_transport
 
     def __get_github_gql_client(self, app_context):
@@ -53,7 +55,7 @@ class GithubGQLCallFactory():
             If it is not created yet, the method creates it before returning.
         """
         github_http_transport = self.__get_github_http_transport(app_context)
-        github_gql_client = gql.Client(transport=github_http_transport, fetch_schema_from_transport=True)
+        github_gql_client = gql.Client(transport=github_http_transport, fetch_schema_from_transport=False)
         return github_gql_client
 
     def __send_gql_request(self, app_context, query, params):

--- a/sources/handlers/DeployHandler.py
+++ b/sources/handlers/DeployHandler.py
@@ -2,7 +2,6 @@
     This module defines the handler for deployment with the group.One Deploy Proxy
     This handler is just a API call factory, as there is no special business logic.
 """
-import json
 import requests
 from flask import current_app
 import sources.utils.Constants as cst
@@ -50,4 +49,4 @@ class DeployHandler():
             current_app.logger.error("deploy_commit: GODP call failed.")
             raise ValueError('GODP call failed.')
         result_json = result.json()
-        current_app.logger.info("deploy_commit: GODP Response:\n" + result_json)
+        current_app.logger.info("deploy_commit: GODP Response:\n%s", result_json)


### PR DESCRIPTION
…ify calls

Fix logging errors

doing this to reduce errors on the service

# Description

Joseph reported that a dev escalation workflow failed. Looking at the log, we have some timeouts and errors with the GQL API of GitHub: I am trying to add retries and reduce the load by not fetching GQL schema.
Also fixed a logger issue

## Documentation

NA

## Type of change
*Delete options that are not relevant.*

- [x] Bug fix (non-breaking change which fixes an issue).


## New dependencies
NA

## Risks
NA