### PR TITLE
Add SaaS User Agents when generating IPs

### DIFF
--- a/sources/handlers/ServerListHandler.py
+++ b/sources/handlers/ServerListHandler.py
@@ -65,6 +65,10 @@ class ServerListHandler():
                 ovh_ipv6 += server_ips[IpAddress.IP_ADDRESS_IPV6] + "\n"
         text += ovh_ipv4
         text += ovh_ipv6
+        # SaaS User Agents
+        text += "User Agents:\n"
+        text += "WP-Rocket/SaaS Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36\n"
+        text += "WP-Rocket/SaaS Mozilla/5.0 (Linux; Android 13; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Mobile Safari/537.36\n"
         text += "\n"
 
         text += "Dynamic exclusions and inclusions:\n"


### PR DESCRIPTION
Fixes wp-media/TB-TT#87

# Description

Add SaaS User Agents when generating IPs, directly in the list of IPs of RUCSS SaaS
Fixes #87 

## Documentation

### User documentation

The change will automatically be cached and used in our online doc.

### Technical documentation

NA

## Type of change
*Delete options that are not relevant.*

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).

## New dependencies
NA

## Risks
NA

# Checklists

## Feature validation

- [ ] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I wrote comments to explain why it does it.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.
- [x] I listed the introduced external dependencies explicitely on the PR.
- [x] I validated the repo-specific guidelines from CONTRIBUTING.md.

## Observability
- [x] I handled errors when needed.
- [x] I wrote user-facing messages that are understandable and provide actionable feedbacks.
- [x] I prepared ways to observe the implemented system (logs, data, etc.).

## Risks
- [x] I explicitely mentioned performance risks in the PR.
- [x] I explicitely mentioned security risks in the PR.
