### PR TITLE
Add call to CloudFlare to retrieve IPv4 & 6

### DIFF
--- a/sources/handlers/ServerListHandler.py
+++ b/sources/handlers/ServerListHandler.py
@@ -1,10 +1,11 @@
 """
     This module defines the handler for logic related to listing server IPs.
 """
+import requests
 from sources.factories.SlackMessageFactory import SlackMessageFactory
 from sources.factories.OvhApiFactory import OvhApiFactory
 from sources.utils import IpAddress, Duplication
-import requests
+
 
 class ServerListHandler():
     """
@@ -19,14 +20,26 @@ class ServerListHandler():
         self.ovh_api_factory = OvhApiFactory()
 
     def get_cloudflare_proxy_ipv4(self):
+        """
+            Retrieves the list of IPv4 used by CloudFlare and returns it as a string, one IP per line.
+            If an error occurs, it is returned.
+        """
         return self.get_cloudflare_proxy_ips('v4')
 
     def get_cloudflare_proxy_ipv6(self):
+        """
+            Retrieves the list of IPv6 used by CloudFlare and returns it as a string, one IP per line.
+            If an error occurs, it is returned.
+        """
         return self.get_cloudflare_proxy_ips('v6')
 
     def get_cloudflare_proxy_ips(self, ip_version):
+        """
+            Retrieves the list of IP matching ip_version used by CloudFlare and returns it as a string, one IP per line.
+            If an error occurs, it is returned.
+        """
         url = 'https://www.cloudflare.com/ips-' + ip_version + '/'
-        response = requests.get(url)
+        response = requests.get(url, timeout=5)
         if response.status_code == 200:
             ip_list = response.text.strip().split('\n')
             return '\n'.join(ip_list)


### PR DESCRIPTION
# Description

Adds the Cloudflare IPs in the list of IPs used by WP Rocket. groupOne proxies are not used directly anymore for WP Rocket, but they are for RocketCDN.

## Documentation

### User documentation

New IPs listed in the list.

### Technical documentation

HTTP Request to the public list available from CloudFlare.

## Type of change
*Delete options that are not relevant.*

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).

## New dependencies
NA

## Risks
NA

# Checklists

## Feature validation

- [ ] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

