### PR TITLE
Release notes to be sent to ops-deploy

### DIFF
--- a/.github/workflows/ci-on_pr_main_bash.yml
+++ b/.github/workflows/ci-on_pr_main_bash.yml
@@ -91,12 +91,12 @@ jobs:
           name: coverage-report-${{ github.run_id }}
 
       - name: Install dependencies
-        run: pip install git+https://github.com/MathieuLamiot/diff_cover   
+        run: pip install diff-cover
   
       - name: Generate diff-coverage report
         if: github.event_name == 'pull_request'
         run: |
-          diff-cover coverage.xml --compare-branch=origin/${{ github.base_ref }} --markdown-report diff-cover-report.md --exclude test*.py --fail-under=50 --expand_coverage_report
+          diff-cover coverage.xml --compare-branch=origin/${{ github.base_ref }} --markdown-report diff-cover-report.md --exclude test*.py --fail-under=50 --expand-coverage-report
           echo "DIFF_COVER_EXIT_STATUS=$?" >> $GITHUB_ENV
         shell: bash
 

--- a/config/slack.json
+++ b/config/slack.json
@@ -2,5 +2,6 @@
     "dev-team-escalation-channel": "C056ZJMHG0P",
     "engineering-service-team-channel": "C069W48E47N",
     "release-channel" : "C05PGTQHHJ9",
-    "ops-channel": "C88N0811V"
+    "ops-channel": "C88N0811V",
+    "ops-deploy-channel": "C07SXUKRSLE"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,4 +52,4 @@ yarl==1.9.2
 flask-slacksigauth==1.0.9
 freezegun==1.2.2
 pytest-cov==5.0.0
-diff-cover==9.1.1
+diff-cover==9.2.0

--- a/sources/factories/SlackMessageFactory.py
+++ b/sources/factories/SlackMessageFactory.py
@@ -109,6 +109,8 @@ class SlackMessageFactory(SlackFactoryAbstract):
             return self.slack_config["release-channel"]
         if 'ops' == flow:
             return self.slack_config["ops-channel"]
+        if 'ops-deploy' == flow:
+            return self.slack_config["ops-deploy-channel"]
         raise ValueError('Unknown flow for get_channel.')
 
     def get_release_note_review_blocks(self, text):

--- a/sources/handlers/GithubReleaseHandler.py
+++ b/sources/handlers/GithubReleaseHandler.py
@@ -40,5 +40,5 @@ class GithubReleaseHandler():
         blocks = self.slack_message_factory.get_release_note_review_blocks(text)
 
         self.slack_message_factory.post_message(app_context,
-                                                self.slack_message_factory.get_channel('ops'),
+                                                self.slack_message_factory.get_channel('ops-deploy'),
                                                 text, blocks)


### PR DESCRIPTION
# Description

Release notes will be sent to #ops-deploy instead of #ops on Slack.

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Release

## Detailed scenario

When deploying to production for a supported service, TB-TT creates a release note automatically and share it on Slack. The channel used is now #ops-deploy.

## Technical description

### Documentation

NA

### New dependencies

NA

### Risks

NA

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)