### PR TITLE
RUCSS backend deploy slug

### DIFF
--- a/config/apps.json
+++ b/config/apps.json
@@ -11,7 +11,7 @@
         "BackWPup Website": "wpm-backwpup-website",
         "Task AI": "wpm-task-ai",
         "wp-media.me": "wpm-wpmediame",
-        "RUCSS Backend": "rucss-backend"
+        "RUCSS Backend": "wpm-rucss-backend"
     },
     "envList": {
         "staging": "staging",


### PR DESCRIPTION
Match the RUCSS backend project slug with GitLab deploy repo: `wpm-rucss-backend`

https://gitlab.group.one/wp-media/deployment-proxy/deployment-proxy/-/tree/master/server/config/applications?ref_type=heads