### PR TITLE
Chore/doc server urls

### DIFF
--- a/.github/workflows/group.one-deploy-production_v2.yml
+++ b/.github/workflows/group.one-deploy-production_v2.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: production
-      url: https://wpm-tbtt.default.live1-k8s-cph3.one.com/
+      url: https://wpm-tbtt.public-default.k8spod1-cph3.ingress.k8s.g1i.one
     steps:
       - name: Check out private action repo
         uses: actions/checkout@v3

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10,7 +10,7 @@ externalDocs:
   description: Notion Documentation
   url: https://www.notion.so/wpmedia/TB-TT-137d921c1ff947c4a19e9d0a83262e6a?pvs=4
 servers:
-  - url: https://wpm-tbtt.public-default.live1-k8s-cph3.one.com
+  - url: https://wpm-tbtt.public-default.k8spod1-cph3.ingress.k8s.g1i.one
 tags:
   - name: support
     description: Automation for the support team


### PR DESCRIPTION
This pull request updates the production deployment and API documentation URLs to reflect a new domain structure. These changes help ensure that both the deployment workflow and the API documentation point to the correct, current endpoints.

**Deployment and API URL updates:**

* Updated the production environment URL in the GitHub Actions workflow file `.github/workflows/group.one-deploy-production_v2.yml` to use the new `k8spod1-cph3.ingress.k8s.g1i.one` domain.
* Updated the server URL in the OpenAPI specification file `openapi.yaml` to match the new domain.
* 