### PR TITLE
Chore: add Chrome 131 WP-Rocket-SaaS user agents

### DIFF
--- a/sources/handlers/ServerListHandler.py
+++ b/sources/handlers/ServerListHandler.py
@@ -119,6 +119,14 @@ class ServerListHandler():
         text += "WP-Rocket/SaaS Mozilla/5.0 (Linux; Android 13; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Mobile Safari/537.36\n" # noqa
         text += "\n"
 
+        # pylint: disable-next=line-too-long
+        text += "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 (compatible; WP-Rocket-SaaS/1.0; +https://wp-rocket.me/bot/)\n" # noqa
+        text += "\n"
+
+        # pylint: disable-next=line-too-long
+        text += "Mozilla/5.0 (Linux; Android 13; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36 (compatible; WP-Rocket-SaaS/1.0; +https://wp-rocket.me/bot/)\n" # noqa
+        text += "\n"
+
         text += "Dynamic exclusions and inclusions:\n"
         # Defined in https://gitlab.one.com/systems/group.one-authdns/-/blob/main/octodns/wp-rocket.me.yaml?ref_type=heads
         text += "https://b.rucss.wp-rocket.me\n"

--- a/sources/handlers/ServerListHandler.py
+++ b/sources/handlers/ServerListHandler.py
@@ -114,12 +114,6 @@ class ServerListHandler():
         # SaaS User Agents
         text += "User Agents:\n"
         # pylint: disable-next=line-too-long
-        text += "WP-Rocket/SaaS Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36\n" # noqa
-        # pylint: disable-next=line-too-long
-        text += "WP-Rocket/SaaS Mozilla/5.0 (Linux; Android 13; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Mobile Safari/537.36\n" # noqa
-        text += "\n"
-
-        # pylint: disable-next=line-too-long
         text += "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 (compatible; WP-Rocket-SaaS/1.0; +https://wp-rocket.me/bot/)\n" # noqa
         text += "\n"
 

--- a/tests/unit/ServerListHandlerTest.py
+++ b/tests/unit/ServerListHandlerTest.py
@@ -210,7 +210,7 @@ def test_generate_wp_rocket_ips_human_readable(mock_requests):
     assert "https://cpcss.wp-rocket.me" in result
     assert "Remove Unused CSS:" in result
     assert "User Agents:" in result
-    assert "WP-Rocket/SaaS" in result
+    assert "WP-Rocket-SaaS/1.0" in result
     assert "Dynamic exclusions and inclusions:" in result
     assert "https://b.rucss.wp-rocket.me" in result
     assert "RocketCDN subscription:" in result


### PR DESCRIPTION
# Description

Adds two new user agent strings to the server list — desktop and mobile — using Chrome 131 with the `WP-Rocket-SaaS/1.0` bot identifier appended.

## Type of change

- [x] Chore

## Detailed scenario

### What was tested

N/A — static string addition, no logic changed.

### How to test

Hit the server list endpoint and verify the two new user agent lines appear in the response.

### Affected Features & Quality Assurance Scope

Server list output only.

## Technical description

### Documentation

N/A

### New dependencies

None.

### Risks

None.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No tests needed — purely additive static string, no logic.